### PR TITLE
linecharts y axis failed automated mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-all: TimeSeries.mpk
+all: TimeSeriesWidget.mpk
 
-TimeSeries.mpk:
-	cd src && zip -r ../TimeSeries.mpk *
+TimeSeriesWidget.mpk:
+	cd src && zip -r ../TimeSeriesWidget.mpk *
 
 clean:
-	rm -f TimeSeries.mpk
+	rm -f TimeSeriesWidget.mpk

--- a/src/TimeSeries/widget/TimeSeries.js
+++ b/src/TimeSeries/widget/TimeSeries.js
@@ -192,7 +192,7 @@ define([
           if (dataFormat == "bytes") {
             return this.convertBytesToString;
           } else {
-            return d3.format(",.1s");
+            return d3.format(".1f");
           }
         },
 

--- a/src/TimeSeries/widget/TimeSeries.js
+++ b/src/TimeSeries/widget/TimeSeries.js
@@ -238,8 +238,13 @@ define([
 
           nv.addGraph(function() {
             var chart;
+            var maxValCandidates = [];
             if (graphData.render == "line") {
               chart = nv.models.lineChart();
+              for (var i = 0; i < data.length; i++) {
+                maxValCandidates.push(Math.max( ...data[i].values ));
+              }
+                chart.lines.forceY([0.0, Math.max( ...maxValCandidates )]);
             } else {
               chart = nv.models.stackedAreaChart();
               chart = chart.showControls(false);


### PR DESCRIPTION
This PR fixes issues with Y axis automated labeling. One example of the problem itself is below:

![object_cache](https://cloud.githubusercontent.com/assets/5015104/23745209/b6c5bb00-04b7-11e7-81bc-a78506f6b5f8.PNG)

For the stacked area charts everything seems fine and dandy but for linecharts the Y axis seem to be problematic, enforcing min starting val fixes this issue and makes graphs okay again