### PR TITLE
for percentage graphs do .1f formatting

### DIFF
--- a/src/TimeSeries/widget/TimeSeries.js
+++ b/src/TimeSeries/widget/TimeSeries.js
@@ -191,6 +191,8 @@ define([
         _getYAxisFormat: function (dataFormat) {
           if (dataFormat == "bytes") {
             return this.convertBytesToString;
+          } else if (dataFormat == "percentage") {
+            return d3.format(".1f");
           } else {
             return d3.format(".4s");
           }


### PR DESCRIPTION
With the recent changes and .4s formatting, we got most of the graphs correct except one.

The percentage graphs break under .4s formatting IF the value is between 0 and 1.

```

> var d3 = require("d3");
undefined
> var f = d3.format(".4s")
undefined
> f(0.06)
'60.00m'

```

This PR fixes that case by using .1f formatting for percentage graphs