### PR TITLE
set max Y label to 100.0 for percentage graphs

### DIFF
--- a/src/TimeSeries/widget/TimeSeries.js
+++ b/src/TimeSeries/widget/TimeSeries.js
@@ -246,7 +246,11 @@ define([
               for (var i = 0; i < data.length; i++) {
                 maxValCandidates.push(Math.max.apply(null, data[i].values));
               }
+              if (graphData.datatype == "percentage") {
+                chart.lines.forceY([0.0, 100.0]);
+              } else {
                 chart.lines.forceY([0.0, Math.max.apply(null, maxValCandidates)]);
+              }
             } else {
               chart = nv.models.stackedAreaChart();
               chart = chart.showControls(false);


### PR DESCRIPTION
For percentage graphs it is visually much better to anchor the Y label to 100.0. 

Before:
![memory_percentage_before](https://cloud.githubusercontent.com/assets/5015104/24108612/6ba8b070-0d8e-11e7-8bcb-dc3c57575060.png)

After:
![after](https://cloud.githubusercontent.com/assets/5015104/24108619/6ecf7996-0d8e-11e7-9121-7d51daa622b3.png)
