### PR TITLE
Remove any open tooltips on deconstruction

### DIFF
--- a/src/TimeSeries/widget/TimeSeries.js
+++ b/src/TimeSeries/widget/TimeSeries.js
@@ -90,6 +90,7 @@ define([
         uninitialize: function () {
           logger.debug(this.id + ".uninitialize");
             // Clean up listeners, helper objects, etc. There is no need to remove listeners added with this.connect / this.subscribe / this.own.
+          d3.selectAll(".nvtooltip").remove();
         },
 
         // We want to stop events on a mobile device


### PR DESCRIPTION
When a page gets redrawn and the legend is being displayed, it will never disappear -- this fix will explicitly remove it when the widget gets uninitialized.